### PR TITLE
C++11 --> C++14

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+RUN apt-get update && apt-get -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y autoconf automake bzip2 cmake g++ libboost-all-dev libbz2-dev libcurl4-openssl-dev liblzma-dev make python3 wget zlib1g-dev && \
+
+    # install Google Sparsehash (needed for BioBloom)
+    wget -qO- "https://github.com/sparsehash/sparsehash/archive/refs/tags/sparsehash-2.0.4.tar.gz" | tar -zx && \
+    cd sparsehash-* && ./configure && make && make install && cd .. && rm -rf sparsehash-* && \
+
+    # install sdsl-lite (needed for BioBloom)
+    wget -qO- "https://github.com/simongog/sdsl-lite/releases/download/v2.1.1/sdsl-lite-2.1.1.tar.gz.offline.install.gz" | tar -zx && \
+    cd sdsl-lite-* && ./install.sh /usr/local/ && cd .. && rm -rf sdsl-lite-* && \
+
+    # install BioBloom
+    wget -qO- "https://github.com/bcgsc/biobloom/releases/download/2.3.5/biobloomtools-2.3.5.tar.gz" | tar -zx && \
+    cd biobloomtools-* && sed -i 's/c++11/c++14/g' configure.ac && ./configure && make && make install && cd .. && rm -rf biobloomtools-* && \
+
+    # clean up
+    apt-get clean && rm -rf /root/.cache /tmp/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CHECK_LIB([dl], [dlopen])
 AC_TYPE_SIZE_T
 
 # Set compiler flags. (TODO Probably doing some bad stuff here)
-AC_SUBST(CXXFLAGS,"-std=c++11 $CXXFLAGS")
+AC_SUBST(CXXFLAGS,"-std=c++14 $CXXFLAGS")
 AC_SUBST(AM_CXXFLAGS, "-Wall -Wextra -Werror $AM_CXXFLAGS")
 
 # Options to configure.


### PR DESCRIPTION
When I tried to install BioBloom, I installed the most recent version of Boost, and I got the following compile warning, which was turned into a compile error due to `-Werror`:

```
The minimum language standard to use Boost.Math will be C++14 starting in July 2023 (Boost 1.82 release)
```

Replacing `-std=c++11` with `-std=c++14` in `configure.ac` fixed the issue